### PR TITLE
now including Ira in any role (not just host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What could I do in about 45 seconds that would take the database I had painstaki
 
 I present to you, as my minimum minimum, _minimum_ viable product, "A Touch of [Ira] Glass."
 
-The script `touch_of_glass.rb` will pull and print a random sampling of my database's collection of 15,841 utterances made by Ira Glass over the course of 577 episodes (2451 acts, including prologues).
+The script `touch_of_glass.rb` will pull and print a random sampling of my database's collection of 24,333 utterances made by Ira Glass over the course of 577 episodes (2451 acts, including prologues).
 
 A sampling, below. 
 

--- a/touch_of_glass.rb
+++ b/touch_of_glass.rb
@@ -1,11 +1,11 @@
 # load 'config/database.rb'
 # load 'config/environment.rb'
 
-num_chunks = Chunk.where({personrole_id: 1}).length
+num_chunks = Person.first.chunks.count
 
 index = (Random.rand * num_chunks).ceil
 
-glass_me = Chunk.where({personrole_id: 1}).offset(index).take(1)
+glass_me = Person.first.chunks.offset(index).take(1)[0]
 
-puts "\n\n#{glass_me[0].text}\n\n"
+puts "\n\n#{glass_me.text}\n\n"
 


### PR DESCRIPTION
first iteration only was getting 15,841 utterances with Ira as host. associations now make it easy to get person.chunks, which includes utterances ('chunks' of text/speech) that the person said in any role (host, interviewer, subject, guest, or various misspellings each thereof)
